### PR TITLE
tsuru: add manpage

### DIFF
--- a/Formula/tsuru.rb
+++ b/Formula/tsuru.rb
@@ -10,7 +10,9 @@ class Tsuru < Formula
   def install
     system "bash", "-c", "test $( go version|awk '{print \$3}' | sed 's/^[^0-9]*\\([0-9]\\)[^0-9]*\\([0-9]\\).*/\\1\\2/') -lt 14 && echo ERROR: tsuru requires Go 1.4 or later, your version is: $(go version) && exit 1 || echo proceeding ..."
     system "bash", "-c", "GOPATH=\"$PWD\" go build -o tsuru github.com/tsuru/tsuru-client/tsuru"
+    system "python", "src/github.com/tsuru/tsuru-client/docs/source/exts/man_pages.py"
     bin.install "tsuru"
+    man8.install "src/github.com/tsuru/tsuru-client/docs/source/exts/tsuru.8"
     bash_completion.install "src/github.com/tsuru/tsuru-client/misc/bash-completion" => "tsuru"
   end
 end


### PR DESCRIPTION
DO NOT MERGE

This is the change needed to support the manpage introduced by tsuru/tsuru-client#10. The latest release of tsuru-client doesn't support it yet, so we need to merge this pull request in a future release of the client.
